### PR TITLE
Windows modification by jlh, 2016/05/12

### DIFF
--- a/Delete_Temporary_Files.php
+++ b/Delete_Temporary_Files.php
@@ -42,8 +42,7 @@ if ( (preg_match('/\D/', $Directory_Name))
   {echo 'Invalid directory name.';}
 else
 {
-    system("/usr/local/bin/rm -r /tmp/$Directory_Name");
-    system("/usr/local/bin/rm -r temporary/$Directory_Name");
+    system("rmdir \"./temporary/$Directory_Name\" /s /q");
 }
   # {system("rm -r temporary/$Directory_Name");}
 ?>

--- a/Process_LaTeX.php
+++ b/Process_LaTeX.php
@@ -47,28 +47,39 @@ if($_POST)
 else
     $formula = $_GET['formula'];
 
+$encodedFormula = $formula;
+
 # PHP versions < 6 have a feature called "magic quotes" inteded to make input 
 # safe by escaping dangerous characters. If this feature is enabled, strip the 
 # extra slashed it adds.
-if(get_magic_quotes_gpc())
+if(get_magic_quotes_gpc()) {
     $formula = stripslashes($formula);
+    print("Stripped 'magic quotes' extra slashes $formula<br>\n");
+}
 
 # PHP tries to undo the percent encoding, but the following restores the
 # encoding because it's also handy for passing a string as an argument.
 # "escapeshellarg" is used for added security.
-$LaTeX_String = escapeshellarg(urlencode($formula));
+# $LaTeX_String = escapeshellarg(urlencode($formula));
+$LaTeX_String = urlencode($formula); # jlh - the above caused trouble on my windows machine setting
+#$LaTeX_String_Display = str_replace('%', '%%',$LaTeX_String);
+
 
 # Call PERL to generate the PNG and display the required baseline offset. If
 # necessary, the PERL script will also display any error messages.
-if ($_GET['dont_del'])
-    system("/usr/local/bin/perl LaTeX_Converter.pl --URL=\"$LaTeX_String\" --Dont_Del");
-else
-    system("/usr/local/bin/perl LaTeX_Converter.pl --URL=\"$LaTeX_String\"");
+if ($_GET['dont_del']) {
+    print("Calling perl LaTeX_Converter.pl --URL=\"$LaTeX_String\" --Dont_Del<br>\n");
+    system("perl LaTeX_Converter.pl --URL=\"$LaTeX_String\" --Dont_Del");
+} else {
+    print("Calling perl LaTeX_Converter.pl --URL=\"$LaTeX_String\"<br>\n");
+    system("perl LaTeX_Converter.pl --URL=\"$LaTeX_String\"");
+}
 
 #log the IP address
 $dtime = date('r'); 
 $ip = getenv("REMOTE_ADDR");
-$fp = fopen("/home/campus/ntoner/liwLog.txt", "a"); 
-fputs($fp, "$dtime: $ip\n"); 
+#$fp = fopen("G:/xampp/htdocs/process_latex/requestLog.txt", "a"); 
+$fp = fopen("./requestLog.txt", "a"); # log ip in local file
+fputs($fp, "$dtime: $ip $\n"); 
 fclose($fp);
 ?>


### PR DESCRIPTION
running on windows (for me, 64 bit win 8) with
  XAMPP for Windows 5.6.14
  MiKTeX 2.9                          (latex, dvipng)
  Strawberry Perl (64-bit) 5.22.0.1   (perl)
  ImageMagick-6.9.2-Q16               (convert, identify)
executables of the packages mentioned above have to be on system's search path.
URL on client side word macro has to be modified to match server side installtaion.
